### PR TITLE
Fix syntax error breaking file parsing

### DIFF
--- a/otl06.xml
+++ b/otl06.xml
@@ -27,7 +27,7 @@
 		<DialogOption id="18" texten="Oh, okay I guess it won't get any worse. Thank you, bye." actiononEnd="opinionEffect=2;actionHangup;" operator="Caller" />
 		<DialogOption id="reminder" texten="Hello? Are you there?" operator="Caller" />
 		<DialogOption id="reminder2" texten="Hello? Stupid phone it's hung up again!" operator="Caller" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+        <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
 	</dialog>
 	<aar>
 		<reportElement id="caller" texten="An elderly woman called and reported being dizzy." />

--- a/otl16.xml
+++ b/otl16.xml
@@ -34,7 +34,7 @@
         <DialogOption id="end" texten="..." actionOnEnd="actionHangup" addToAAR="story_1" operator="Caller" />
         <DialogOption id="reminder" texten="Hello? We need help down here!" operator="Caller" />
         <DialogOption id="reminder2" texten="Someone help!" operator="Caller" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+        <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
       </dialog>
       <aar>
         <reportElement id="story_1" texten="The caller reported explosions at a marathon finish line." />

--- a/otl17.xml
+++ b/otl17.xml
@@ -50,7 +50,7 @@
         <DialogOption id="12" texten="If the baby is not breathing or not breathing normally, cover the baby's mouth and nose with your mouth and give 2 gentle breaths. Each breath should be about 1 second long." elementProperties="option=35;" addToAAR="" operator="Operator" emotions="" />
         <DialogOption id="35" texten="One... Two... " elementProperties="option=13;" addToAAR="" operator="Caller" emotions="" />
         <DialogOption id="13" texten="Continue with 30 pumps and 2 breaths until help arrives." elementProperties="option=end;" addToAAR="" operator="Operator" emotions="" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+        <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
       </dialog>
       <aar>
         <reportElement id="story_1" texten="Infant locked in hot car." />

--- a/otl18.xml
+++ b/otl18.xml
@@ -52,7 +52,7 @@
         <DialogOption id="20" texten="Can your rip your shirt again to cover up the wound? You need to put pressure on it to stop the bleeding." elementProperties="option=25;" addToAAR="" operator="Operator" emotions="" />
         <DialogOption id="37" texten="I need you to stay calm, emergency services are on their way." elementProperties="option=38;" addToAAR="" operator="Operator" emotions="" />
         <DialogOption id="38" texten="Please have them hurry! I might pass out!" elementProperties="option=end;" addToAAR="" operator="Caller" emotions="" />
-<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+        <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
       </dialog>
       <aar>
         <reportElement id="story_1" texten="An Uber driver shot and robbed their rider." />

--- a/otl19.xml
+++ b/otl19.xml
@@ -28,7 +28,7 @@
         <DialogOption id="end" texten="..." elementProperties="" actionOnEnd="actionHangup" addToAAR="" operator="Caller" emotions="" />
         <DialogOption id="reminder" texten="Help me they're dying!" elementProperties="" addToAAR="" operator="Caller" emotions="" />
         <DialogOption id="reminder2" texten="Please help me!" elementProperties="" addToAAR="" operator="Caller" emotions="" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+        <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
       </dialog>
       <aar>
         <reportElement id="story_1" texten="Ella's parents have been shot during a home invasion." />

--- a/otl21.xml
+++ b/otl21.xml
@@ -46,7 +46,7 @@
  <dialogOption id="enda" operator="Caller:" texten="Ok, thank you!" actionOnEnd="actionHangup" />
  <dialogOption id="reminder" operator="Caller:" texten="Are you there?" />
  <dialogOption id="reminder2" operator="Caller:" texten="Hello?" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+ <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
  </dialog>
  <aar>
  <reportElement id="yesterday" texten="The accident took place yesterday and there was no need of intervention." />

--- a/otl22.xml
+++ b/otl22.xml
@@ -44,7 +44,7 @@
  <dialogOption id="end" operator="Caller:" texten="Okay. I'm waiting. Thank you so much for your help, goodbye!" actionOnEnd="actionHangup" />
  <dialogOption id="reminder" operator="Caller:" texten="Hello? . . . . . Is anybody there? . . . . . Am I just supposed to leave him here like this?" />
  <dialogOption id="reminder2" operator="Caller:" texten="Hello? Isn't 911 supposed to answer? There's a man here and he's foaming at the mouth, he's flailing around and noone's answering me. . . . 911, hello?! Hello! Why is noone answering me? . . Oh no, he-he's stopped moving. I-Is something wrong? . . . Oh, I-I just heard a crack - I think I just heard a crack. I think he broke something. He's flailing, why isn't anyone answering me? . . . Hello? Hello?! I pay taxes for a reason, 911, hello?" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+ <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
  </dialog>
  <aar>
  <reportElement id="story" texten="Caller saw a man with epileptic seizure." />

--- a/otl23.xml
+++ b/otl23.xml
@@ -34,7 +34,7 @@ sex=W;" id="sister2" texten="Child" />
  <dialogOption id="notouch1" operator="Caller:" texten="I won't touch it!!!" default="stay" />
  <dialogOption id="reminder" operator="Caller:" emotions="[crying]" texten="[crying]" />
  <dialogOption id="reminder2" operator="Caller:" emotions="[crying]" texten="Help me!" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+ <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
  </dialog>
  <aar>
  <reportElement id="story" texten="Male teenager shot himself in his own house. Bullet caused loss of consciousness and massive bleeding. His two little sisters have been in the house during an accident. Older girl (10 years old) called 911." />

--- a/otl24.xml
+++ b/otl24.xml
@@ -24,7 +24,7 @@
 		<dialogOption id="end" operator="Operator:" texten="Okay, the police and medical services are on their way and should be there shortly." actionOnEnd="actionHangup" addtoAAR="storya"/>
 		<dialogOption id="reminder" operator="Caller:" texten="Hello? Hello, are you there still?"/>
 		<dialogOption id="reminder2" operator="Caller:" texten="Have I lost signal?!"/>
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+        <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
 	</dialog>
 	<aar>
 		<reportElement id="fail" texten="The Operator hungup on a genuine emergency."/>

--- a/otl25.xml
+++ b/otl25.xml
@@ -29,7 +29,7 @@
 			<dialogOption id="end" operator="Caller" texten="Yeah get here! I ain't gonna wait all day!" actionOnEnd="actionHangup;" />
 			<dialogOption id="reminder" operator="Caller" texten="So? I ain't gonna wait all day." actionOnEnd="actionHangup;" />
 			<dialogOption id="reminder2" operator="Caller" texten="You there?" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+            <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
 		</dialog>
 		<aar>
 			<reportElement id="story" texten="The caller was drunk. He called an ambulance, but intervention was not necessary" />

--- a/otl26.xml
+++ b/otl26.xml
@@ -49,7 +49,7 @@
         <DialogOption id="40" texten=". . . . . . . Liam?" elementProperties="" addToAAR="" operator="Operator" emotions="" actionOnEnd="actionHangup;" />
         <DialogOption id="reminder" texten="Hello?" elementProperties="" addToAAR="" operator="Caller" emotions="" />
         <DialogOption id="reminder2" texten="..." elementProperties="" addToAAR="" operator="Caller" emotions="" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+        <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
       </dialog>
       <aar />
     </conversation>

--- a/otl27.xml
+++ b/otl27.xml
@@ -71,7 +71,7 @@
         <DialogOption id="49" texten="Sure I can do that, thank you." elementProperties="" actionOnEnd="actionHangup;" addToAAR="hangup" operator="Caller" emotions="" />
         <DialogOption id="reminder" texten="..." elementProperties="" addToAAR="" operator="Caller" emotions="" />
         <DialogOption id="reminder2" texten="..." elementProperties="" addToAAR="" operator="Caller" emotions="" />
-		<DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue."operator="Operator" />
+        <DialogOption id="back" texten="This call is part of OtL. Please visit github.com/SoharicMedia/OtL/issues to report this issue." operator="Operator" />
       </dialog>
       <aar>
         <reportElement id="nonemerg" texten="The caller was a young child who had crashed their model plane. An emergency presence was not required." />


### PR DESCRIPTION
This PR fixes an error in the XML files that breaks the game's call parser, causing none of the calls to ever occur.

This was tested by going in game after making these changes and seeing the added calls come through.